### PR TITLE
Add auto-generated Javadocs hosted on GitHub Pages

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -103,6 +103,8 @@ jobs:
         run: |
           echo "# ✓ Successfully Published Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📖 API docs: https://frc-team-4143.github.io/MW-Lib/" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Published by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -130,3 +132,56 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "⚠️ _GitHub Packages requires authentication even for public repositories_" >> $GITHUB_STEP_SUMMARY
+
+  deploy-docs:
+    name: Generate & Deploy Javadocs
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout code (develop)
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Generate Javadoc
+        run: ./gradlew javadoc --info
+
+      - name: Assemble site (main docs + bundled vendor javadoc)
+        run: |
+          mkdir -p site
+          cp -r build/docs/javadoc/. site/
+          # Bundled vendor javadoc that we linkOffline to (paths must match the linkOffline URLs).
+          if [ -d build/docs/vendor ]; then
+            mkdir -p site/vendor
+            cp -r build/docs/vendor/. site/vendor/
+          fi
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -114,6 +114,23 @@ After publishing, your package will be available at:
 https://github.com/FRC-Team-4143/MW-Lib/packages
 ```
 
+## API Documentation (GitHub Pages)
+
+The **Make Release** workflow (`.github/workflows/make-release.yml`) generates Javadoc and deploys
+it to GitHub Pages via its `deploy-docs` job. The docs are a single "latest" site published at:
+
+```
+https://frc-team-4143.github.io/MW-Lib/
+```
+
+The `javadoc` task (configured in `build.gradle`) cross-links to WPILib and several vendor libraries.
+CTRE Phoenix6 / maple-sim / PlayingWithFusion / Grapple don't host browsable Javadoc, so we download
+their `-javadoc.jar`, publish an extracted copy under `/vendor/<name>/`, and link to it.
+
+**One-time setup (repo admin):** In **GitHub repo Settings → Pages**, set **Source = "GitHub
+Actions"**. This is required for the `actions/deploy-pages` deploy step and cannot be set from the
+workflow file. To preview locally: `./gradlew javadoc` then open `build/docs/javadoc/index.html`.
+
 ## Using the Published Package
 
 To use this library in another project, add to your `build.gradle`:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Java library for FRC (FIRST Robotics Competition) teams, providing utilities for swerve drive, mechanisms, geometry, and more.
 
+📖 **API docs:** https://frc-team-4143.github.io/MW-Lib/
+
 ## Features
 
 - **Swerve Drive Library**: Complete swerve drive implementation with Phoenix 6 support

--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,76 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+// ---- Javadoc generation + API cross-linking ----
+// Published docs site root (GitHub Pages). Used to build linkOffline URLs.
+def docsBaseUrl = 'https://frc-team-4143.github.io/MW-Lib'
+
+// Vendors that ship a real -javadoc.jar but have no plain-linkable hosted site (CTRE's public
+// site is Doxygen, the others don't host javadoc at all). We download each -javadoc.jar, host an
+// extracted copy under <docsBaseUrl>/vendor/<name>/, and linkOffline to it so their types
+// (TalonFX, CANcoder, etc.) render as clickable links. The release workflow publishes the
+// extracted dirs alongside the main docs.
+def vendorJavadocs = [
+    phoenix6: 'com.ctre.phoenix6:wpiapi-java:26.1.1',
+    maplesim: 'org.ironmaple:maplesim-java:0.4.0-beta',
+    pwf     : 'com.playingwithfusion.frc:PlayingWithFusion-java:2026.2.25',
+    grapple : 'au.grapplerobotics:libgrapplefrcjava:2025.1.3',
+]
+
+configurations { vendorJavadoc }
+dependencies {
+    vendorJavadocs.each { name, coord -> vendorJavadoc "${coord}:javadoc@jar" }
+}
+
+def vendorDocsRoot = layout.buildDirectory.dir('docs/vendor')
+def extractVendorJavadoc = tasks.register('extractVendorJavadoc') {
+    description = 'Extracts vendor -javadoc.jar artifacts for offline javadoc cross-linking.'
+    group = 'Documentation'
+    inputs.files configurations.vendorJavadoc
+    outputs.dir vendorDocsRoot
+    doLast {
+        def artifacts = configurations.vendorJavadoc.resolvedConfiguration.resolvedArtifacts
+        vendorJavadocs.each { name, coord ->
+            def artifact = artifacts.find { a ->
+                "${a.moduleVersion.id.group}:${a.moduleVersion.id.name}:${a.moduleVersion.id.version}" == coord
+            }
+            copy {
+                from zipTree(artifact.file)
+                into vendorDocsRoot.get().dir(name)
+            }
+        }
+    }
+}
+
+javadoc {
+    dependsOn extractVendorJavadoc
+    title = 'MW-Lib API'
+    options {
+        encoding = 'UTF-8'
+        charSet = 'UTF-8'
+        memberLevel = JavadocMemberLevel.PROTECTED         // document the public API surface
+        addBooleanOption('Xdoclint:none', true)            // don't fail on malformed/missing comments
+        addStringOption('Xmaxwarns', '1')                  // keep CI logs quiet
+
+        // Plain online cross-links (verified to serve an element-list):
+        links 'https://docs.oracle.com/en/java/javase/17/docs/api/'
+        links 'https://github.wpilib.org/allwpilib/docs/release/java/'   // WPILib (Pose2d, Command, units, ...)
+        links 'https://javadoc.io/doc/com.google.code.gson/gson/2.13.2/'
+        links 'https://javadoc.io/doc/org.ejml/ejml-simple/0.44.0/'
+        links 'https://javadoc.io/doc/org.dyn4j/dyn4j/5.0.2/'
+    }
+
+    // Bundled vendor docs (downloaded + self-hosted). linksOffline reads the element-list from the
+    // extracted dir locally and emits links pointing at where we publish it. Called on `options`
+    // directly so method resolution doesn't depend on the nested-closure delegate chain.
+    vendorJavadocs.each { name, coord ->
+        options.linksOffline("${docsBaseUrl}/vendor/${name}".toString(),
+                             vendorDocsRoot.get().dir(name).asFile.absolutePath.toString())
+    }
+
+    failOnError = false   // loose doc comments / vendor quirks shouldn't break a release
+}
+
 // Disable C++ builds - Java only project
 
 // Enable publish.gradle for vendor dependency


### PR DESCRIPTION
Configure a hardened javadoc task and publish the docs to GitHub Pages on release as a single "latest" site.

- build.gradle: lenient javadoc task (Xdoclint:none, failOnError=false) with cross-links to Java SE, WPILib, and gson/ejml/dyn4j (javadoc.io). Vendors without browsable javadoc (CTRE Phoenix6, maple-sim, PlayingWithFusion, Grapple) ship a -javadoc.jar, which is downloaded, extracted, self-hosted under /vendor/<name>/, and cross-linked via linksOffline so their types render as clickable links.
- make-release.yml: new deploy-docs job (needs: publish) that generates javadoc, assembles the site (docs + bundled vendor docs), and deploys via actions/deploy-pages.
- README.md / PUBLISHING.md: document the docs URL and the one-time "Pages source = GitHub Actions" repo setting.